### PR TITLE
apache configuration link to a dedicated directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-MAINTAINER Tomas Jasek<tomsik68 (at) gmail (dot) com> 
+MAINTAINER Tomas Jasek<tomsik68 (at) gmail (dot) com>
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --fix-missing
@@ -14,6 +14,10 @@ RUN ln -sf /opt/lampp/lampp /usr/bin/lampp
 
 # Enable XAMPP web interface(remove security checks)
 RUN sed -i.bak s'/Require local/Require all granted/g' /opt/lampp/etc/extra/httpd-xampp.conf
+
+# Enable includes of several configuration files
+RUN mkdir /opt/lampp/apache2/conf.d && \
+    echo "IncludeOptional /opt/lampp/apache2/conf.d/*.conf" >> /opt/lampp/etc/httpd.conf
 
 # Create a /www folder and a symbolic link to it in /opt/lampp/htdocs. It'll be accessible via http://localhost:[port]/www/
 # This is convenient because it doesn't interfere with xampp, phpmyadmin or other tools in /opt/lampp/htdocs

--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ default SSH password is 'root'.
 ssh root@localhost -p 41061
 ```
 
-### Use your own configuration
-
-In your home directory, create a `my_apache_conf` directory in which you place your modified version of `httpd.conf`. Launch the service with
+### get a shell terminal inside your container
 
 ```
-docker run --name myXampp -p 41061:22 -p 41062:80 -d -v ~/my_web_pages:/www  -v ~/my_apache_conf:/opt/lamp/apache2/conf tomsik68/xampp
+docker exec -ti myXampp bash
+```
+
+### Use your own configuration
+
+In your home directory, create a `my_apache_conf` directory in which you place any number of apache configuration directive files. As soon as they end up with the .conf extension, they will be used by the image.
+
+```
+docker run --name myXampp -p 41061:22 -p 41062:80 -d -v ~/my_web_pages:/www  -v ~/my_apache_conf:/opt/lampp/apache2/conf.d tomsik68/xampp
 ```
 
 ### Restart the server
@@ -39,4 +45,3 @@ Once you have modified configuration for example
 docker exec myXampp /opt/lampp/lampp restart
 ```
 Please report any issues in issues section on github: https://github.com/tomsik68/docker-xampp/issues where we can track them conveniently. Thanks :)
-


### PR DESCRIPTION
Doing a little more digging on how apache conf works in xampp, I have modified the docker file to enable adding addtionnal conf files without changing the ones which are added by xampp or bitnami.
I have tested the resulting docker image both with conf file directory linked and without conf file directory linked. Works well.

I have updated the Readme.md accordingly.