### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:buster
 MAINTAINER Tomas Jasek<tomsik68 (at) gmail (dot) com>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -8,7 +8,7 @@ RUN apt upgrade -y
 # curl is needed to download the xampp installer, net-tools provides netstat command for xampp
 RUN apt-get -y install curl net-tools
 
-RUN curl -Lo xampp-linux-installer.run "https://www.apachefriends.org/xampp-files/7.3.7/xampp-linux-x64-7.3.7-1-installer.run?from_af=true"
+RUN curl -Lo xampp-linux-installer.run "https://www.apachefriends.org/xampp-files/8.0.0/xampp-linux-x64-8.0.0-0-installer.run?from_af=true"
 RUN chmod +x xampp-linux-installer.run
 RUN bash -c './xampp-linux-installer.run'
 RUN ln -sf /opt/lampp/lampp /usr/bin/lampp


### PR DESCRIPTION
- Updated debian version from debian jessie (8, release date 2015-04-25), which already reached EOL, to debian buster (10, 2019-07-06)
- Updated XAMPP version from 7.3.7-1 to 8.0.0-1