### PR TITLE
Improve dockerfile, update xampp to 8.2.4

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,8 +32,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tomsik68/xampp:8.1.6,tomsik68/xampp:8,tomsik68/xampp:latest
-          build-args: XAMPP_URL=https://downloadsapachefriends.global.ssl.fastly.net/8.1.6/xampp-linux-x64-8.1.6-0-installer.run?from_af=true
+          tags: tomsik68/xampp:8.2.4,tomsik68/xampp:8,tomsik68/xampp:latest
+          build-args: XAMPP_URL=https://altushost-swe.dl.sourceforge.net/project/xampp/XAMPP%20Linux/8.2.4/xampp-linux-x64-8.2.4-0-installer.run
 
   xampp7:
     runs-on: ubuntu-latest
@@ -57,30 +57,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tomsik68/xampp:7.4.29,tomsik68/xampp:7
-          build-args: XAMPP_URL=https://downloadsapachefriends.global.ssl.fastly.net/7.4.29/xampp-linux-x64-7.4.29-1-installer.run?from_af=true
-
-  xampp5:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      -
-        name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: tomsik68/xampp:5.6.40,tomsik68/xampp:5
-          build-args: XAMPP_URL=https://www.apachefriends.org/xampp-files/5.6.40/xampp-linux-x64-5.6.40-1-installer.run?from_af=true
+          tags: tomsik68/xampp:7.4.33,tomsik68/xampp:7
+          build-args: XAMPP_URL=https://netix.dl.sourceforge.net/project/xampp/XAMPP%20Linux/7.4.33/xampp-linux-x64-7.4.33-0-installer.run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![DockerHub:latest](https://github.com/tomsik68/docker-xampp/workflows/Docker%20Image%20CI/badge.svg)](https://github.com/tomsik68/docker-xampp/actions/workflows/docker-image.yml) 
-[![Docker Hub](https://img.shields.io/docker/pulls/tomsik68/xampp)](https://hub.docker.com/r/tomsik68/xampp)
-[![XAMPP version](https://img.shields.io/badge/XAMPP-8.1.6-1abc9c.svg)](https://www.apachefriends.org/)  [![Gitter](https://badges.gitter.im/docker-xampp/community.svg)](https://gitter.im/docker-xampp/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) 
+![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/tomsik68/docker-xampp/docker-image?style=for-the-badge&label=Docker%20Image%20CI)
+![Docker Pulls](https://img.shields.io/docker/pulls/tomsik68/xampp?style=for-the-badge)
+![Static Badge](https://img.shields.io/badge/XAMPP%20version-8.2.4-A?style=for-the-badge&link=https%3A%2F%2Fwww.apachefriends.org%2F)
+
 
 | PHP version | Corresponding tag |
 --------------|---------------------
@@ -99,6 +100,6 @@ If you used the flag `-p 41062:80` with `docker run`, just browse to http://loca
 Currently, the Docker image is built only for PHP 5, 7 and 8.
 If you need another version, you can easily build a Docker image yourself, here's how:
 
-1. Clone this repo
+1. Clone this repo (local clone is sufficient, no need to fork)
 2. Find the URL to a URL to your desired version. List of versions can be found here: https://sourceforge.net/projects/xampp/files/XAMPP%20Linux/
 3. Build the image using e.g. `docker build --build-arg XAMPP_URL="https://www.apachefriends.org/xampp-files/5.6.40/xampp-linux-x64-5.6.40-1-installer.run?from_af=true" .`

--- a/startup.sh
+++ b/startup.sh
@@ -1,2 +1,0 @@
-/opt/lampp/lampp start
-/usr/bin/supervisord -n

--- a/supervisord-openssh-server.conf
+++ b/supervisord-openssh-server.conf
@@ -1,5 +1,0 @@
-[program:openssh-server]
-command=/usr/sbin/sshd -D
-numprocs=1
-autostart=true
-autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,13 @@
+[program:openssh-server]
+command=/usr/sbin/sshd -D
+numprocs=1
+autostart=true
+autorestart=true
+
+[program:xampp]
+command=/opt/lampp/lampp start
+numprocs=1
+exitcodes=0
+autostart=true
+autorestart=unexpected
+redirect_stderr=true


### PR DESCRIPTION
Dockerfile improvements:

- Use caching layer to cache the installer
- Improve apt usage inside the container
- Remove installer after use (this results in smaller image)
- Use supervisor to start xampp instead of startup script