### PR TITLE
Add Docker Compose example and MySQL data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ docker exec myXampp /opt/lampp/lampp restart
 
 If you used the flag `-p 41062:80` with `docker run`, just browse to http://localhost:41062/phpmyadmin/ .
 
+### Docker compose example
+```
+version: '3.8'
+
+services:
+  xampp:
+    image: tomsik68/xampp
+    ports:
+      - "44162:22"
+      - "41063:80"
+    volumes:
+      # Mount your web pages
+      - ./xampp/my_pages:/www
+      # Mount your apache configuration
+      - ./xampp/my_apache_conf/:/opt/lampp/apache2/conf.d
+      #Save MySQL data to be persistent
+      # add the dbs as needed
+      - ./xampp/mysql/mydb:/opt/lampp/var/mysql/mydb
+    restart: always
+```
+
 ## Use a Different XAMPP or PHP Version
 
 Currently, the Docker image is built only for PHP 5, 7 and 8.


### PR DESCRIPTION
I needed to run this docker image whit docker compose particularly, also I needed data persistent with mysql.

- Added a Docker Compose example to the README.md file demonstrating how to mount a volume in the MySQL directory for data persistence.

This example is usefull if you needto run the tomsik68/xampp Docker image with Docker Compose and you require ensuring data persistence for MySQL. However, attempting to mount a volume directly to the MySQL directory may lead to errors during boot up. This PR addresses this issue by providing a clear example and instructions on how to correctly configure Docker Compose for MySQL data persistence.

<img width="1094" alt="Screenshot 2024-05-08 at 9 40 42 a m" src="https://github.com/tomsik68/docker-xampp/assets/102494060/cf978b29-b7cd-4f5b-82f2-eff02010ab66">